### PR TITLE
諸々のバージョンを上げる

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,5 +25,12 @@ tasks.test {
     useJUnitPlatform()
 }
 kotlin {
-    jvmToolchain(16)
+    jvmToolchain(21)
+}
+
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(21))
+        vendor.set(JvmVendorSpec.JETBRAINS)
+    }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    kotlin("jvm") version "1.9.23"
+    kotlin("jvm") version "2.0.21"
     id("com.github.johnrengelman.shadow") version "8.1.1"
     application
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,6 @@ repositories {
 }
 
 dependencies {
-    implementation(platform("org.jetbrains.kotlin:kotlin-bom"))
     implementation("net.dv8tion","JDA","5.1.2")
     testImplementation(kotlin("test"))
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,7 +13,7 @@ repositories {
 
 dependencies {
     implementation(platform("org.jetbrains.kotlin:kotlin-bom"))
-    implementation("net.dv8tion","JDA","5.0.0-beta.24")
+    implementation("net.dv8tion","JDA","5.1.2")
     testImplementation(kotlin("test"))
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Tue Jun 18 22:28:53 JST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("org.gradle.toolchains.foojay-resolver-convention") version "0.5.0"
+    id("org.gradle.toolchains.foojay-resolver-convention") version "0.8.0"
 }
 rootProject.name = "OverclockCalculationBOT"
 


### PR DESCRIPTION
全体的に変にバージョンが低かったので、バージョンを上げています

# java.toolchainについて
これを指定していると、Gradleが自動でJDKをダウンロードしてくれます。つまり、他の開発者がいる場合に自動でJavaのバージョンを合わせてくれるので、問題が起きにくくて楽です。
